### PR TITLE
Using argparse to parse argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.mp3
 *.srt
 *.list
+.idea
 autosub/

--- a/split.py
+++ b/split.py
@@ -1,6 +1,17 @@
-import subprocess
-import sys
+import argparse
 import os
+import subprocess
+
+
+def parse_arg():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-ot", "--origin",
+                        help="original track")
+    parser.add_argument("-t", "--tracks",
+                        help="track list")
+    args = parser.parse_args()
+    return args.origin, args.tracks
+
 
 def get_title(original_track):
     cmd_string = 'ffmpeg -i "%s" -f ffmetadata meta.txt' % original_track
@@ -25,14 +36,8 @@ def get_title(original_track):
 def main():
     """split a music track into specified sub-tracks by calling ffmpeg from the shell"""
 
-    # check command line for original file and track list file
-    if len(sys.argv) != 3:
-        print('usage: split <original_track> <track_list>')
-        exit(1)
-
     # record command line args
-    original_track = sys.argv[1]
-    track_list = sys.argv[2]
+    original_track, track_list = parse_arg()
 
     track_title = get_title(original_track)
 

--- a/sub2track.py
+++ b/sub2track.py
@@ -1,6 +1,16 @@
-import subprocess
-import sys
-import re
+import argparse
+
+
+def parse_arg():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--subtitle",
+                        help="subtitle path")
+    parser.add_argument("-t", "--tracks",
+                        help="track list")
+    parser.add_argument("-p", "--prefix",
+                        help="prefix")
+    args = parser.parse_args()
+    return args.subtitle, args.tracks, args.prefix.replace(' ', '_')
 
 
 def write_track_list(tracks, track_list):
@@ -23,15 +33,8 @@ def append_track(tracks, start, line_timing, filename, current_chapter):
 def main():
     """create track list file from subtitle"""
 
-    # check command line for original file and track list file
-    if len(sys.argv) != 4:
-        print('usage: sub2track <subtitle> <track_list> <prefix>')
-        exit(1)
-
     # record command line args
-    subtitle = sys.argv[1]
-    track_list = sys.argv[2]
-    prefix = sys.argv[3].replace(' ', '_')
+    subtitle, track_list, prefix = parse_arg()
 
     tracks = []
     # read each line of the track list and split into start, end, name

--- a/subsplit.sh
+++ b/subsplit.sh
@@ -2,6 +2,6 @@
 for i in *.srt
 do
     eval 'fbname=$(basename "$i" .srt)'
-    python sub2track.py "$i" "$fbname.list" "$fbname"
-    python split.py "$fbname.mp3" "$fbname.list"
+    python sub2track.py -s "$i" -t "$fbname.list" -p "$fbname"
+    python split.py -ot "$fbname.mp3" -t "$fbname.list"
 done


### PR DESCRIPTION
The PR intends to use [argparse](https://docs.python.org/3/howto/argparse.html) to parse arguments, for better readability.